### PR TITLE
Unfreeze Player Rotation

### DIFF
--- a/Assets/Scenes/FirstScene.unity
+++ b/Assets/Scenes/FirstScene.unity
@@ -1002,7 +1002,7 @@ Rigidbody:
   m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
-  m_Constraints: 122
+  m_Constraints: 10
   m_CollisionDetection: 0
 --- !u!114 &477318085
 MonoBehaviour:


### PR DESCRIPTION
Change in "Constraints" of Player`s Rigidbody component. Player Rotation was enabled because it`s (player) stopped in the edge of the sectors.